### PR TITLE
fix: prevent workflow failure when grep finds no CRLF files

### DIFF
--- a/.github/workflows/verify-no-crlf-line-endings.yml
+++ b/.github/workflows/verify-no-crlf-line-endings.yml
@@ -22,7 +22,7 @@ jobs:
 
           # Find all markdown files containing CRLF and store the list in a variable.
           # This is more efficient as it only runs the expensive command once.
-          files_with_crlf=$(grep -l $'\r' $(find . -type f -name "*.md"))
+          files_with_crlf=$(grep -l $'\r' $(find . -type f -name "*.md") || true)
 
           # Check if the variable is empty.
           if [ -z "$files_with_crlf" ]; then


### PR DESCRIPTION
# Summary

<!-- Provide a high-level summary of the changes and their intent. -->

## Related Issues & Discussions

<!-- Link to any relevant issues, discussions, or external references. -->
- Closes #

## Changes

<!-- List the key updates. Group related items together for quick scanning. -->
<!-- Example: - Added new prompt describing XYZ workflow -->

## Resource Checklist

<!-- Tick every resource type you touched in this PR. Remove rows that do not apply. -->
- [ ] Prompts (`prompts/`)
- [ ] Instructions (`instructions/`)
- [ ] Chat modes (`chatmodes/`)
- [ ] Toolkits (`toolkits/`)
- [ ] Scripts or tooling (`scripts/`)
- [ ] Documentation (`README*.md`, `references/`, etc.)
- [ ] Other (describe below)

## Validation

<!-- Document how you verified the changes. Include commands, screenshots, or links to test results. -->
- [ ] `npm run readme-update`
- [ ] `npm run toolkit-validate`
- [ ] Additional checks (describe below)

## Notes for Reviewers

<!-- Call out anything that warrants special attention, open questions, or follow-up work. -->
